### PR TITLE
Add E2E tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,36 @@ jobs:
 
       - name: Test
         run: npm test
-        
-           
+
+  e2e:
+    name: End-to-End Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { freshApp } from './helpers';
+
+test.describe('App shell', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+  });
+
+  test('loads the app and shows the header', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Clean CV Maker' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Version History' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Personal Information' })).toBeVisible();
+    await expect(
+      page.getByText(/designed primarily for IT professionals/)
+    ).toBeVisible();
+  });
+
+  test('toggles dark mode and persists the choice across reloads', async ({ page }) => {
+    const html = page.locator('html');
+    await expect(html).not.toHaveClass(/dark/);
+
+    await page.getByRole('button', { name: 'Switch to dark mode' }).click();
+
+    await expect(html).toHaveClass(/dark/);
+    expect(await page.evaluate(() => localStorage.getItem('theme'))).toBe('dark');
+
+    await page.reload();
+    await expect(html).toHaveClass(/dark/);
+  });
+
+  test('switches language and applies RTL direction for Arabic', async ({ page }) => {
+    await page.getByRole('button', { name: 'English' }).click();
+    await page.getByRole('button', { name: 'العربية' }).click();
+
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.getByRole('heading', { name: 'منشئ السيرة الذاتية' })).toBeVisible();
+
+    // Switching back to a LTR language restores dir="ltr".
+    await page.getByRole('button', { name: 'العربية' }).click();
+    await page.getByRole('button', { name: 'English' }).click();
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.getByRole('heading', { name: 'Clean CV Maker' })).toBeVisible();
+  });
+
+  test('resolves hyphenated locale codes (pt-BR, zh-CN) correctly', async ({ page }) => {
+    // Regression test: i18next's `supportedLngs` + `nonExplicitSupportedLngs`
+    // combination used to silently fall back to English for any registered
+    // language code containing a region subtag, even on an exact match.
+    for (const [code, sectionHeading] of [
+      ['pt-BR', 'Informações Pessoais'],
+      ['zh-CN', '个人信息'],
+    ] as const) {
+      await page.evaluate((c) => localStorage.setItem('i18nextLng', c), code);
+      await page.reload();
+
+      await expect(page.getByRole('heading', { name: sectionHeading })).toBeVisible();
+      await expect(page.locator('html')).toHaveAttribute('lang', code);
+    }
+  });
+});

--- a/e2e/dynamic-lists.spec.ts
+++ b/e2e/dynamic-lists.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { freshApp } from './helpers';
+
+// ExperienceYearsSection, ProjectsWorkedSection, and LanguagesSection are
+// always rendered (not gated behind a switch), and start with empty arrays,
+// so on a fresh page these are the only "Add ..." controls of their kind.
+test.describe('Always-on dynamic list widgets', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+  });
+
+  test('adds and removes a language entry', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Language' }).click();
+    await page.locator('[name="languages.0.language"]').fill('Portuguese');
+    await page.locator('[name="languages.0.proficiency"]').selectOption('5');
+    await expect(page.locator('[name="languages.0.proficiency"]')).toHaveValue('5');
+
+    // The remove button is a sibling in the same row as the language input.
+    // The row also has a drag handle (a <div role="button">, for keyboard
+    // drag-and-drop), so a tag selector is used to target only the real
+    // <button> element.
+    await page
+      .locator('[name="languages.0.language"]')
+      .locator('xpath=../..')
+      .locator('button')
+      .click();
+    await expect(page.locator('[name="languages.0.language"]')).toHaveCount(0);
+  });
+
+  test('adds an experience-years entry and shows the computed duration', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Experience' }).click();
+    await page.locator('[name="experienceYears.0.technology"]').fill('TypeScript');
+    await page.locator('[name="experienceYears.0.startDate"]').fill('2018-01');
+    await expect(page.getByText(/\+ years/)).toBeVisible();
+  });
+
+  test('adds a projects-worked entry', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Project' }).click();
+    await page
+      .locator('[name="projectsWorked.0"]')
+      .fill('Migrated the billing system to microservices');
+    await expect(page.locator('[name="projectsWorked.0"]')).toHaveValue(
+      'Migrated the billing system to microservices'
+    );
+  });
+});

--- a/e2e/exports.spec.ts
+++ b/e2e/exports.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { freshApp, fillRequiredPersonalInfo } from './helpers';
+
+test.describe('CV export', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+  });
+
+  test('downloads an HTML CV once required fields are valid', async ({ page }) => {
+    const data = await fillRequiredPersonalInfo(page);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Download HTML' }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe(
+      `${data.fullName.replace(/\s+/g, '-').toLowerCase()}-cv.html`
+    );
+    await expect(page.getByText('HTML CV generated successfully')).toBeVisible();
+  });
+
+  test('blocks HTML export and points to the first invalid field when required data is missing', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Download HTML' }).click();
+    await expect(
+      page.getByText('Please fill in all required fields before generating HTML')
+    ).toBeVisible();
+    await expect(page.getByText('Full name is required')).toBeVisible();
+  });
+
+  test('downloads a PDF CV once required fields are valid', async ({ page }) => {
+    const data = await fillRequiredPersonalInfo(page);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 20_000 }),
+      page.getByRole('button', { name: 'Download PDF' }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe(
+      `${data.fullName.replace(/\s+/g, '-').toLowerCase()}-cv.pdf`
+    );
+    await expect(page.getByText('PDF CV generated successfully')).toBeVisible();
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Navigates to the app and clears persisted state (localStorage) so each test
+ * starts from a clean slate, regardless of execution order.
+ */
+export async function freshApp(page: Page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+}
+
+export interface RequiredPersonalInfo {
+  fullName: string;
+  title: string;
+  location: string;
+  email: string;
+  phone: string;
+  bio: string;
+}
+
+export const DEFAULT_PERSONAL_INFO: RequiredPersonalInfo = {
+  fullName: 'Ada Lovelace',
+  title: 'Senior Software Engineer',
+  location: 'London, UK',
+  email: 'ada.lovelace@example.com',
+  phone: '+44 20 7946 0958',
+  bio: 'Pioneering software engineer with a passion for analytical engines and elegant algorithms.',
+};
+
+/** Fills every required top-level personal info field via its RHF `name` attribute. */
+export async function fillRequiredPersonalInfo(
+  page: Page,
+  overrides: Partial<RequiredPersonalInfo> = {}
+) {
+  const data = { ...DEFAULT_PERSONAL_INFO, ...overrides };
+
+  await page.locator('[name="fullName"]').fill(data.fullName);
+  await page.locator('[name="title"]').fill(data.title);
+  await page.locator('[name="location"]').fill(data.location);
+  await page.locator('[name="email"]').fill(data.email);
+  await page.locator('[name="phone"]').fill(data.phone);
+  await page.locator('[name="bio"]').fill(data.bio);
+
+  return data;
+}
+
+export type SectionName = 'experiences' | 'education' | 'projects' | 'certificates';
+
+/**
+ * Toggles ON a collapsible section (Experience/Education/Projects/Certificates)
+ * and expands it. The switch and the expand/collapse chevron are independent
+ * pieces of state in CollapsibleSection, so both actions are required before
+ * the section's fields become visible. `PersonalInfoForm` wraps each section
+ * in a `data-section` container, which we use as a stable scoping anchor.
+ */
+export async function enableAndExpandSection(
+  page: Page,
+  section: SectionName,
+  switchLabel: string
+) {
+  const container = page.locator(`[data-section="${section}"]`);
+  // The switch's own input is visually hidden (sr-only) behind a styled
+  // track div that intercepts pointer events, so click its text label
+  // instead - exactly what a real user would do.
+  await container.getByText(switchLabel, { exact: true }).click();
+  await container.getByRole('button').first().click();
+}

--- a/e2e/personal-info.spec.ts
+++ b/e2e/personal-info.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { freshApp, fillRequiredPersonalInfo, enableAndExpandSection } from './helpers';
+
+test.describe('Personal info form', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+  });
+
+  test('shows validation errors when saving an empty completed version', async ({ page }) => {
+    await page.getByRole('button', { name: 'Save Completed Version' }).click();
+
+    await expect(page.getByText('Full name is required')).toBeVisible();
+    await expect(page.getByText('Professional title is required')).toBeVisible();
+    await expect(page.getByText('Location is required')).toBeVisible();
+    // An empty string fails the schema's .email() check before its .min(1)
+    // check runs, so this is the message actually shown, not "Email is
+    // required".
+    await expect(page.getByText('Invalid email address')).toBeVisible();
+    await expect(page.getByText('Phone number is required')).toBeVisible();
+    await expect(page.getByText('Professional bio is required')).toBeVisible();
+  });
+
+  test('flags an invalid email address', async ({ page }) => {
+    await page.locator('[name="email"]').fill('not-an-email');
+    await page.locator('[name="fullName"]').click(); // blur the email field
+    await expect(page.getByText('Invalid email address')).toBeVisible();
+  });
+
+  test('rejects a malformed GitHub URL', async ({ page }) => {
+    await page.locator('[name="githubUrl"]').fill('not-a-url');
+    await page.locator('[name="fullName"]').click();
+    await expect(page.getByText('Invalid GitHub URL')).toBeVisible();
+  });
+
+  test('renders a live preview once required data is entered', async ({ page }) => {
+    const data = await fillRequiredPersonalInfo(page);
+
+    await expect(page.getByRole('heading', { name: 'CV Preview' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: data.fullName, exact: true })).toBeVisible();
+    await expect(page.getByText(data.title)).toBeVisible();
+    await expect(page.getByText(data.location)).toBeVisible();
+    await expect(page.getByRole('link', { name: data.email })).toBeVisible();
+  });
+
+  test('willRelocate checkbox reflects in the preview', async ({ page }) => {
+    await fillRequiredPersonalInfo(page);
+    await page.locator('[name="willRelocate"]').check();
+
+    // A case-sensitive regex distinguishes the preview's "Available for
+    // relocation" text from the form's "Available for Relocation" label.
+    await expect(page.getByText(/Available for relocation/)).toBeVisible();
+  });
+
+  test('showcased projects appear in the live preview', async ({ page }) => {
+    // Regression test: the "I have projects to showcase" section used to be
+    // captured in the form and included in the HTML/PDF exports, but was
+    // silently missing from CVPreview entirely.
+    await fillRequiredPersonalInfo(page);
+    await enableAndExpandSection(page, 'projects', 'I have projects to showcase');
+
+    await page.locator('[name="projects.0.name"]').fill('Analytical Engine Simulator');
+    await page.locator('[name="projects.0.description"]').fill('A simulator for the Analytical Engine.');
+    await page.locator('[name="projects.0.startDate"]').fill('2024-01');
+
+    await expect(
+      page.getByRole('heading', { name: 'Analytical Engine Simulator' })
+    ).toBeVisible();
+    await expect(page.getByText('A simulator for the Analytical Engine.')).toBeVisible();
+  });
+});

--- a/e2e/toggleable-sections.spec.ts
+++ b/e2e/toggleable-sections.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { freshApp, enableAndExpandSection } from './helpers';
+
+test.describe('Work experience section', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+    await enableAndExpandSection(page, 'experiences', 'I have work experience');
+  });
+
+  test('fills a role and adds/removes additional roles', async ({ page }) => {
+    await page.locator('[name="experiences.0.companyName"]').fill('Analytical Engines Ltd');
+    await page.locator('[name="experiences.0.roles.0.title"]').fill('Lead Engineer');
+    await page.locator('[name="experiences.0.roles.0.description"]').fill('Built the first algorithm.');
+
+    await page.getByRole('button', { name: 'Add Role' }).click();
+    await expect(page.getByRole('heading', { name: 'Role 2' })).toBeVisible();
+    await page.locator('[name="experiences.0.roles.1.title"]').fill('Consultant');
+
+    // Only non-first roles are removable; the remove button is a sibling of
+    // the role's own heading, inside their shared header row.
+    await page
+      .getByRole('heading', { name: 'Role 2' })
+      .locator('xpath=..')
+      .getByRole('button')
+      .click();
+    await expect(page.getByRole('heading', { name: 'Role 2' })).toHaveCount(0);
+  });
+
+  test('adds an achievement to a role', async ({ page }) => {
+    // The role starts with zero achievements, so the first click adds
+    // "Achievement 1".
+    await page.getByRole('button', { name: 'Add Achievement' }).click();
+    await page.getByPlaceholder('Achievement 1').fill('Shipped the analytical engine v2');
+    await expect(page.getByPlaceholder('Achievement 1')).toHaveValue(
+      'Shipped the analytical engine v2'
+    );
+  });
+
+  test('adds a second experience entry', async ({ page }) => {
+    // "Add Experience" also exists in the always-visible "Experience (in
+    // years)" widget elsewhere on the page, so this must be scoped.
+    await page
+      .locator('[data-section="experiences"]')
+      .getByRole('button', { name: 'Add Experience', exact: true })
+      .click();
+    await expect(page.getByRole('heading', { name: 'Experience 2' })).toBeVisible();
+  });
+
+  test('hides the section again when the switch is turned off', async ({ page }) => {
+    await page.getByText('I have work experience', { exact: true }).click();
+    await expect(page.locator('[name="experiences.0.companyName"]')).toHaveCount(0);
+  });
+});
+
+test.describe('Education section', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+    await enableAndExpandSection(page, 'education', 'I want to add education');
+  });
+
+  test('fills institution details and adds a topic', async ({ page }) => {
+    await page.locator('[name="education.0.institution"]').fill('University of London');
+    await page.locator('[name="education.0.degree"]').fill('Mathematics');
+
+    await page.getByRole('button', { name: 'Add Topic' }).click();
+    await page.getByPlaceholder('Enter a topic or skill learned').fill('Number theory');
+    await expect(page.getByPlaceholder('Enter a topic or skill learned')).toHaveValue(
+      'Number theory'
+    );
+  });
+
+  test('current checkbox disables the end date field', async ({ page }) => {
+    const endDate = page.locator('[name="education.0.endDate"]');
+    await expect(endDate).toBeEnabled();
+    await page.locator('[name="education.0.current"]').check();
+    await expect(endDate).toBeDisabled();
+  });
+});
+
+test.describe('Certificates section', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+    await enableAndExpandSection(page, 'certificates', 'I have certifications to add');
+  });
+
+  test('never expires checkbox disables the expiry date field', async ({ page }) => {
+    const expiryDate = page.locator('[name="certificates.0.expiryDate"]');
+    await expect(expiryDate).toBeEnabled();
+    await page.locator('[name="certificates.0.neverExpires"]').check();
+    await expect(expiryDate).toBeDisabled();
+  });
+
+  test('shows a warning when marked as a free certification', async ({ page }) => {
+    await expect(page.getByText(/Free certifications may be viewed less favorably/)).toHaveCount(
+      0
+    );
+    await page.locator('[name="certificates.0.isPaid"]').uncheck();
+    await expect(page.getByText(/Free certifications may be viewed less favorably/)).toBeVisible();
+  });
+});
+
+test.describe('Projects section', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+    await enableAndExpandSection(page, 'projects', 'I have projects to showcase');
+  });
+
+  test('source code URL field is shown by default (source is open)', async ({ page }) => {
+    await expect(page.locator('[name="projects.0.sourceCodeUrl"]')).toBeVisible();
+
+    await page.locator('[name="projects.0.isSourceOpen"]').uncheck();
+    await expect(page.locator('[name="projects.0.sourceCodeUrl"]')).toHaveCount(0);
+  });
+
+  test('selects a suggested technology and adds a custom one', async ({ page }) => {
+    await page.getByRole('button', { name: 'React', exact: true }).click();
+    await expect(page.getByText('1/10 technologies selected')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'React ×' })).toBeVisible();
+
+    await page.getByPlaceholder('Add custom technology').fill('MyFramework');
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+    await expect(page.getByText('2/10 technologies selected')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'MyFramework ×' })).toBeVisible();
+
+    // Clicking a selected chip removes it again.
+    await page.getByRole('button', { name: 'React ×' }).click();
+    await expect(page.getByText('1/10 technologies selected')).toBeVisible();
+  });
+});

--- a/e2e/versions.spec.ts
+++ b/e2e/versions.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { freshApp, fillRequiredPersonalInfo } from './helpers';
+
+// The version-history panel is a right-hand overlay; scoping to its root
+// avoids clashing with any similarly-styled elements in the page behind it.
+const panelLocator = (page: import('@playwright/test').Page) =>
+  page.locator('div.fixed.right-0.top-0');
+
+test.describe('Version history', () => {
+  test.beforeEach(async ({ page }) => {
+    await freshApp(page);
+  });
+
+  test('autosaves a draft on blur and lists it in the history panel', async ({ page }) => {
+    const data = await fillRequiredPersonalInfo(page);
+    await expect(page.getByText('CV auto-saved as draft')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Version History' }).click();
+    const panel = panelLocator(page);
+    await expect(panel.getByRole('heading', { name: 'Version History' })).toBeVisible();
+    await expect(panel.getByText(data.fullName)).toBeVisible();
+    await expect(panel.getByText('Draft')).toBeVisible();
+  });
+
+  test('saving a completed version replaces any existing drafts', async ({ page }) => {
+    await fillRequiredPersonalInfo(page);
+    await expect(page.getByText('CV auto-saved as draft')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Save Completed Version' }).click();
+    await expect(page.getByText('CV saved as completed version')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Version History' }).click();
+    const panel = panelLocator(page);
+    await expect(panel.getByText('Completed')).toBeVisible();
+    await expect(panel.getByText('Draft')).toHaveCount(0);
+  });
+
+  test('renames, exports, loads, and deletes a saved version', async ({ page }) => {
+    const data = await fillRequiredPersonalInfo(page);
+    await page.getByRole('button', { name: 'Save Completed Version' }).click();
+    await expect(page.getByText('CV saved as completed version')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Version History' }).click();
+    const panel = panelLocator(page);
+    const card = panel.locator('div.rounded-lg.p-3').first();
+    await expect(card).toBeVisible();
+
+    // Rename: icon buttons have no accessible name, so they're targeted by
+    // their fixed position within the card's action row (Edit, Export, Delete).
+    const [editButton, exportButton, deleteButton] = [
+      card.locator('button').nth(0),
+      card.locator('button').nth(1),
+      card.locator('button').nth(2),
+    ];
+
+    await editButton.click();
+    await expect(page.getByRole('heading', { name: 'Rename Version' })).toBeVisible();
+    const nameInput = page.getByPlaceholder('Enter version name');
+    await nameInput.fill('Grant Application Draft');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(card.getByText('Grant Application Draft')).toBeVisible();
+
+    // Export downloads a JSON snapshot of the version.
+    const [download] = await Promise.all([page.waitForEvent('download'), exportButton.click()]);
+    expect(download.suggestedFilename()).toBe(
+      `cv-${data.fullName.toLowerCase().replace(/\s+/g, '-')}-completed.json`
+    );
+
+    // Load repopulates the form with the version's data.
+    await card.getByRole('button', { name: 'Load Version' }).click();
+    await expect(page.locator('[name="fullName"]')).toHaveValue(data.fullName);
+
+    // Delete removes the card and shows the empty state.
+    await page.getByRole('button', { name: 'Version History' }).click();
+    await deleteButton.click();
+    await expect(panel.getByText('No versions saved yet.')).toBeVisible();
+  });
+
+  test('imports a valid version JSON file', async ({ page }) => {
+    await page.getByRole('button', { name: 'Version History' }).click();
+    const panel = panelLocator(page);
+
+    const validVersion = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'Imported Version',
+      timestamp: Date.now(),
+      status: 'draft',
+      data: {
+        fullName: 'Grace Hopper',
+        title: 'Rear Admiral',
+        location: 'Arlington, VA',
+        email: 'grace.hopper@example.com',
+        phone: '+1 555 010 2020',
+        githubUrl: '',
+        linkedinUrl: '',
+        willRelocate: false,
+        bio: 'Pioneer of computer programming and COBOL.',
+      },
+    };
+
+    await page.getByLabel('Import CV Version').setInputFiles({
+      name: 'cv-version.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(validVersion)),
+    });
+
+    await expect(panel.getByText(/Grace Hopper/)).toBeVisible();
+  });
+
+  test('rejects an invalid version JSON file', async ({ page }) => {
+    await page.getByRole('button', { name: 'Version History' }).click();
+
+    await page.getByLabel('Import CV Version').setInputFiles({
+      name: 'broken.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify({ not: 'a valid version' })),
+    });
+
+    await expect(page.getByText('Invalid CV format')).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/forms": "^0.5.11",
@@ -868,6 +869,22 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -4428,6 +4445,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/png-js": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "format:write": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,md,json}\" \"*.{js,ts,json}\"",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
@@ -32,7 +35,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.61.1",
+    "@tailwindcss/aspect-ratio": "^0.4.2",
+    "@tailwindcss/container-queries": "^0.1.1",
+    "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.3.2",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -50,10 +58,6 @@
     "prettier": "^3.9.5",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.2",
-    "@tailwindcss/forms": "^0.5.11",
-    "@tailwindcss/typography": "^0.5.20",
-    "@tailwindcss/aspect-ratio": "^0.4.2",
-    "@tailwindcss/container-queries": "^0.1.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.1.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const BASE_PATH = '/clean-cv-maker/';
+const baseURL = `http://localhost:${PORT}${BASE_PATH}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
+  timeout: 30_000,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && npm run preview -- --port 4173 --strictPort',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## 📑 Description
Add E2E tests

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add Playwright end-to-end test suite and integrate it into CI.

Build:
- Add Playwright configuration and scripts, including a preview web server, to run browser-based tests locally and in CI.

CI:
- Add a dedicated GitHub Actions job to run Playwright E2E tests and upload HTML reports as artifacts.

Tests:
- Add comprehensive Playwright E2E coverage for app shell, personal info, dynamic lists, toggleable sections, exports, and version history.
- Introduce shared Playwright helpers for bootstrapping the app and filling required personal information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for app rendering, themes, languages, dynamic form sections, validation, previews, CV exports, and version history.
  * Added regression checks for locale handling, form interactions, imports, downloads, and persisted settings.

* **Chores**
  * Added automated Playwright test commands and browser test configuration.
  * Pull requests now run end-to-end tests automatically and retain test reports for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->